### PR TITLE
Update to match latest version of Hammer

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ exports.install = function (Vue) {
         },
         unbind: function () {
             this.el.hammer.off(this.arg, this.handler)
-            if (!this.el.hammer._eventHandler.length) {
+            if (!this.el.hammer.eventHandlers.length) {
+                this.el.hammer.dispose()
                 this.el.hammer = null
             }
         }


### PR DESCRIPTION
Internals of Hammerjs [changed](https://github.com/EightMedia/hammer.js/blob/fc6b1c23b61be607650497f4902ad8c4abd5e7e2/src/instance.js#L39). Old `unbind` code is no longer working with latest releases of Hammer and throws an exception when unbinding, which unfortunately stalls the page...
