### PR TITLE
changed README to make the reference to the next branch more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # vue-touch
 
-> Touch events plugin for Vue.js. **This plugin does not support Vue 2.0 yet.**
+> Touch events plugin for Vue.js
 
 This is a directive wrapper for Hammer.js 2.0.
 
 ## Install
 
-> This branch is only compatible with Vue 1.0. For the Vue 2.0 compatible rewrite, see the `next` branch
+> **This branch is only compatible with Vue 1.0**. For the Vue 2.0 compatible rewrite, see the [next](https://github.com/vuejs/vue-touch/tree/next) branch.
 
 #### CommonJS
 


### PR DESCRIPTION
When I opened the README for this plugin, the first thing I saw was “This plugin does not support Vue 2.0 yet” written in bold at the top. So I sighed and went back to Google to try to find an alternative. Thankfully I found this stack overflow question that brought me back here: https://stackoverflow.com/questions/42693953/touch-events-in-vue-2-0. 

It would help to change the README to be more clear, and guide people to the next branch.